### PR TITLE
Completar contracte comunicació amb serveis bot

### DIFF
--- a/adapter.yml
+++ b/adapter.yml
@@ -2,8 +2,46 @@ openapi: 3.0.4
 info:
   title: Communication contract between application back-end and bot service
   description: This file defines the communication contract between the AI league application back-end and the different bot services.
-  version: 1.0.0
+  version: 1.0.1
 
 paths:
+  /message/{matchId}:
+    post:
+      summary: Send message to communicate with bots
+      description: This endpoint allows to send a message to a bot
+      parameters:
+        - name: matchId
+          in: path
+          required: true
+          description: The ID of the match to retrieve messages for
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageDTO'
+      responses:
+        '200':
+          description: Message received successfully by bot
 
 components:
+  schemas:
+
+    MessageDTO:
+      type: object
+      properties:
+        botId:
+          type: integer
+          format: int64
+        text:
+          type: string
+        time:
+          type: string
+          format: date-time
+      required:
+        - botId
+        - text
+        - time

--- a/bot.yml
+++ b/bot.yml
@@ -4,6 +4,13 @@ info:
   description: This file defines the communication contract bot service.
   version: 1.0.0
 
+servers:
+  - url: http://localhost:8080/{version}
+    variables:
+      version:
+        default: api/v0
+        description: API version prefix
+
 paths:
   /bot/health/{botId}:
     get:

--- a/bot.yml
+++ b/bot.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.4
+info:
+  title: Communication contract for bot service
+  description: This file defines the communication contract bot service.
+  version: 1.0.0
+
+paths:
+  /bot/health/{botId}:
+    get:
+      summary: Check health of a bot service
+      description: Allows to know about a bot service connection health
+      parameters:
+        - name: botId
+          in: path
+          required: true
+          description: The ID of the bot to retrieve connection health
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Bot service is healthy
+        '503':
+          description: Bot service is unavailable
+
+components:
+  schemas:


### PR DESCRIPTION
Modificar el contracte OpenAPI de la comunicació entre el back-end i els serveis bot, per tal d'incloure les operacions:

Comprovació de salut.
Enviament de missatge del back-end al bot, incloent missatge, identificador de partit i identificador de bot.
Enviament de resposta del servei bot al back-end, incloent el missatge, identificador de partit i identificador de bot.

adapter i bot separats en fintxers diferents